### PR TITLE
feat: add cobra support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize bartle for the current project",
+	Long: `The init command initializes your project to use bartle and
+creates a bartle file in the project root if it doesn't already exist.'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		file, err := os.ReadFile("./bartle.yml")
+		if err != nil {
+			fmt.Println("Existing bartle file not found. Initializing.")
+		}
+		fmt.Print(string(file))
+
+		f, err := os.Create("./bartle.yml")
+		if err != nil {
+			fmt.Println("Couldn't write file.")
+		}
+
+		defer f.Close()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var lintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Lint a specific commit message.",
+	Long: `The lint command lints the given commit message to validity.
+This can be passed in directly or piped in.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: lint implementation
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lintCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bartle",
+	Short: "Your commit companion.",
+	Long: `Bartle helps keep your git commits to a standard and can
+offer examples when necessary.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Version of bartle",
+	Long:  `The version command gets the current version of bartle.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: version implementation
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/RyanTalbot/bartle
 
 go 1.25.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.7 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
+github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
-import "fmt"
+import "github.com/RyanTalbot/bartle/cmd"
 
 func main() {
-	fmt.Println("Bartle checking in...")
+	cmd.Execute()
 }


### PR DESCRIPTION
This PR adds support for cobra cli. We're starting off with three commands which we'll build out in the coming PRs. Those commands are init, lint, and version.