### PR TITLE
chore: make cobra a direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/RyanTalbot/bartle
 
 go 1.25.0
 
+require github.com/spf13/cobra v1.9.1
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 )


### PR DESCRIPTION
This PR makes cobra a direct dependency in our go mod file.