### PR TITLE
feat(cmd): add version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,18 +1,66 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/RyanTalbot/bartle/internal/version"
 	"github.com/spf13/cobra"
+)
+
+var (
+	versionJSON  bool
+	versionShort bool
 )
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Version of bartle",
-	Long:  `The version command gets the current version of bartle.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: version implementation
+	Short: "Output bartle version information",
+	Long: `Output bartle version information.
+
+By default, prints human-readable text:
+  bartle v0.1.0 (commit abc123, built 2025-08-22T19:22:33Z, by goreleaser)
+
+Use -s for just the version number, -j for JSON, or -js for minimal JSON.`,
+
+	Example: `
+  bartle version      # human-readable
+  bartle version -s   # short only
+  bartle version -j   # full JSON
+  bartle version -js  # minimal JSON`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info := version.Get()
+
+		switch {
+		case versionJSON && versionShort:
+			minimalInfo := struct {
+				Version string `json:"version"`
+			}{Version: info.Version}
+
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			encoder.SetEscapeHTML(false)
+			return encoder.Encode(minimalInfo)
+
+		case versionJSON:
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			encoder.SetEscapeHTML(false)
+			return encoder.Encode(info)
+
+		case versionShort:
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), info.Version)
+			return err
+
+		default:
+			_, err := fmt.Fprintf(cmd.OutOrStdout(),
+				"bartle %s (commit %s, built %s, by %s)\n",
+				info.Version, info.Commit, info.Date, info.BuiltBy,
+			)
+			return err
+		}
 	},
 }
 
 func init() {
+	versionCmd.Flags().BoolVarP(&versionJSON, "json", "j", false, "print version information as JSON")
+	versionCmd.Flags().BoolVarP(&versionShort, "short", "s", false, "print only the version number")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,24 @@
+package version
+
+var (
+	Version = "v0.0.0-dev"
+	Commit  = "HEAD"
+	Date    = "unknown"
+	BuiltBy = "local"
+)
+
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+	BuiltBy string `json:"builtBy"`
+}
+
+func Get() Info {
+	return Info{
+		Version: Version,
+		Commit:  Commit,
+		Date:    Date,
+		BuiltBy: BuiltBy,
+	}
+}


### PR DESCRIPTION
This PR fills out the version command with functionality including JSON and regular text support, as well as short output.