### PR TITLE
feat(cmd): use constructors for commands

### DIFF
--- a/cmd/installhook.go
+++ b/cmd/installhook.go
@@ -13,59 +13,65 @@ var (
 	hookUseAbsolute bool
 )
 
-var installHookCmd = &cobra.Command{
-	Use:   "install-hook",
-	Short: "Install a git commit-msg hook that runs bartle lint",
-	Long: `Installs .git/hooks/commit-msg to enforce your .bartle.yaml rules on every commit.
+func InstallHookCommand() *cobra.Command {
+	var installHookCmd = &cobra.Command{
+		Use:   "install-hook",
+		Short: "Install a git commit-msg hook that runs bartle lint",
+		Long: `Installs .git/hooks/commit-msg to enforce your .bartle.yaml rules on every commit.
 
 By default the hook invokes "bartle lint \"$1\"" (using PATH). Use --absolute to
 embed the absolute path to the bartle binary in the hook for reliability.`,
-	Example: `
+		Example: `
   bartle install-hook
   bartle install-hook --absolute
   bartle install-hook --force`,
-	Args:         cobra.NoArgs,
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		repoRoot, err := hooks.RepoRootFromCwd()
-		if err != nil {
-			return err
-		}
-
-		hookPath := hooks.HookPath(repoRoot)
-
-		var bartleCmd string
-		if hookUseAbsolute {
-			exe, err := os.Executable()
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, err := hooks.RepoRootFromCwd()
 			if err != nil {
-				return fmt.Errorf("resolve bartle path: %w", err)
+				return err
 			}
-			bartleCmd = exe
-		} else {
-			bartleCmd = "bartle"
-		}
 
-		// If a hook exists, decide whether we can/should overwrite
-		exists, isOurs, err := hooks.CheckExisting(hookPath)
-		if err != nil {
-			return err
-		}
-		if exists && !hookForce && !isOurs {
-			return fmt.Errorf("%s already exists and is not managed by Bartle (use --force to overwrite)", hookPath)
-		}
+			hookPath := hooks.HookPath(repoRoot)
 
-		if err := hooks.InstallCommitMsgHook(hookPath, bartleCmd); err != nil {
-			return err
-		}
+			var bartleCmd string
+			if hookUseAbsolute {
+				exe, err := os.Executable()
+				if err != nil {
+					return fmt.Errorf("resolve bartle path: %w", err)
+				}
+				bartleCmd = exe
+			} else {
+				bartleCmd = "bartle"
+			}
 
-		fmt.Fprintln(cmd.OutOrStdout(), "✅ Installed Bartle commit-msg hook at", hookPath)
-		fmt.Fprintln(cmd.OutOrStdout(), "Commits will now be linted automatically.")
-		return nil
-	},
+			// If a hook exists, decide whether we can/should overwrite
+			exists, isOurs, err := hooks.CheckExisting(hookPath)
+			if err != nil {
+				return err
+			}
+			if exists && !hookForce && !isOurs {
+				return fmt.Errorf("%s already exists and is not managed by Bartle (use --force to overwrite)", hookPath)
+			}
+
+			if err := hooks.InstallCommitMsgHook(hookPath, bartleCmd); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "✅ Installed Bartle commit-msg hook at", hookPath)
+			fmt.Fprintln(cmd.OutOrStdout(), "Commits will now be linted automatically.")
+			return nil
+		},
+	}
+
+	installHookCmd.Flags().BoolVarP(&hookForce, "force", "f", false, "overwrite an existing hook")
+	installHookCmd.Flags().BoolVarP(&hookUseAbsolute, "absolute", "a", false, "embed absolute path to bartle binary in hook")
+
+	return installHookCmd
 }
 
 func init() {
-	installHookCmd.Flags().BoolVarP(&hookForce, "force", "f", false, "overwrite an existing hook")
-	installHookCmd.Flags().BoolVarP(&hookUseAbsolute, "absolute", "a", false, "embed absolute path to bartle binary in hook")
-	rootCmd.AddCommand(installHookCmd)
+
+	rootCmd.AddCommand(InstallHookCommand())
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -17,76 +17,80 @@ var (
 	lintMsg string
 )
 
-var lintCmd = &cobra.Command{
-	Use:   "lint [message-file]",
-	Short: "Lint a commit message against .bartle.yaml rules",
-	Long: `Validate a commit message against the style and rules defined in .bartle.yaml.
+func LintCommand() *cobra.Command {
+	var lintCmd = &cobra.Command{
+		Use:   "lint [message-file]",
+		Short: "Lint a commit message against .bartle.yaml rules",
+		Long: `Validate a commit message against the style and rules defined in .bartle.yaml.
 
 You can pass a message directly with -m/--message, a path to a message file
 (e.g. .git/COMMIT_EDITMSG), or pipe a message on stdin.`,
-	Example: `
+		Example: `
   bartle lint -m "feat(ui): add dropdown"
   bartle lint .git/COMMIT_EDITMSG
   echo "fix(api): handle nil pointer" | bartle lint`,
-	Args:          cobra.MaximumNArgs(1),
-	SilenceUsage:  true, // don't print usage on lint failures
-	SilenceErrors: true, // we've already printed friendly errors
-	RunE: func(cmd *cobra.Command, args []string) error {
-		msg := strings.TrimSpace(lintMsg)
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true, // don't print usage on lint failures
+		SilenceErrors: true, // we've already printed friendly errors
+		RunE: func(cmd *cobra.Command, args []string) error {
+			msg := strings.TrimSpace(lintMsg)
 
-		if msg == "" && len(args) == 1 {
-			b, err := os.ReadFile(args[0])
+			if msg == "" && len(args) == 1 {
+				b, err := os.ReadFile(args[0])
+				if err != nil {
+					return fmt.Errorf("read message file: %w", err)
+				}
+				msg = strings.TrimSpace(string(b))
+				// Strip git comment lines (# ...) commonly found in COMMIT_EDITMSG
+				msg = stripGitComments(msg)
+			}
+
+			if msg == "" {
+				stdinMsg, err := readStdinIfPiped()
+				if err != nil {
+					return fmt.Errorf("read stdin: %w", err)
+				}
+				if stdinMsg != "" {
+					msg = stdinMsg
+				}
+			}
+
+			if msg == "" {
+				return errors.New("no commit message provided (use -m, a file path, or pipe on stdin)")
+			}
+
+			// Normalize CRLF
+			msg = strings.ReplaceAll(msg, "\r", "")
+
+			// Load config from repo root
+			cfg, _, err := config.Load()
 			if err != nil {
-				return fmt.Errorf("read message file: %w", err)
+				return fmt.Errorf("load config: %w", err)
 			}
-			msg = strings.TrimSpace(string(b))
-			// Strip git comment lines (# ...) commonly found in COMMIT_EDITMSG
-			msg = stripGitComments(msg)
-		}
 
-		if msg == "" {
-			stdinMsg, err := readStdinIfPiped()
-			if err != nil {
-				return fmt.Errorf("read stdin: %w", err)
+			res := lint.ValidateMessage(msg, cfg)
+			if res.Valid {
+				fmt.Fprintln(cmd.OutOrStdout(), "✅ Commit message is valid!")
+				return nil
 			}
-			if stdinMsg != "" {
-				msg = stdinMsg
+
+			fmt.Fprintln(cmd.OutOrStdout(), "❌ Invalid commit message:")
+			for _, e := range res.Errors {
+				fmt.Fprintln(cmd.OutOrStdout(), e)
 			}
-		}
 
-		if msg == "" {
-			return errors.New("no commit message provided (use -m, a file path, or pipe on stdin)")
-		}
+			// Return an error to produce non-zero exit code (hooks/CI),
+			// but we've already printed the friendly output above.
+			return errors.New("lint failed")
+		},
+	}
+	lintCmd.Flags().StringVarP(&lintMsg, "message", "m", "", "commit message text to lint")
 
-		// Normalize CRLF
-		msg = strings.ReplaceAll(msg, "\r", "")
-
-		// Load config from repo root
-		cfg, _, err := config.Load()
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		res := lint.ValidateMessage(msg, cfg)
-		if res.Valid {
-			fmt.Fprintln(cmd.OutOrStdout(), "✅ Commit message is valid!")
-			return nil
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), "❌ Invalid commit message:")
-		for _, e := range res.Errors {
-			fmt.Fprintln(cmd.OutOrStdout(), e)
-		}
-
-		// Return an error to produce non-zero exit code (hooks/CI),
-		// but we've already printed the friendly output above.
-		return errors.New("lint failed")
-	},
+	return lintCmd
 }
 
 func init() {
-	lintCmd.Flags().StringVarP(&lintMsg, "message", "m", "", "commit message text to lint")
-	rootCmd.AddCommand(lintCmd)
+	rootCmd.AddCommand(LintCommand())
 }
 
 // readStdinIfPiped returns stdin content if data is piped; otherwise "".

--- a/cmd/uninstallhook.go
+++ b/cmd/uninstallhook.go
@@ -11,44 +11,48 @@ var (
 	uninstallForce bool
 )
 
-var uninstallHookCmd = &cobra.Command{
-	Use:   "uninstall-hook",
-	Short: "Uninstall Bartle's git commit-msg hook",
-	Long: `Removes .git/hooks/commit-msg if it was installed by Bartle.
+func UninstallHookCommand() *cobra.Command {
+	var uninstallHookCmd = &cobra.Command{
+		Use:   "uninstall-hook",
+		Short: "Uninstall Bartle's git commit-msg hook",
+		Long: `Removes .git/hooks/commit-msg if it was installed by Bartle.
 
 By default, only removes hooks that contain Bartle's marker.
 Use --force to remove any existing commit-msg hook (a backup is created).`,
-	Example: `
+		Example: `
   bartle uninstall-hook
   bartle uninstall-hook --force`,
-	Args:         cobra.NoArgs,
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		repoRoot, err := hooks.RepoRootFromCwd()
-		if err != nil {
-			return err
-		}
-		hookPath := hooks.HookPath(repoRoot)
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, err := hooks.RepoRootFromCwd()
+			if err != nil {
+				return err
+			}
+			hookPath := hooks.HookPath(repoRoot)
 
-		changed, backupPath, err := hooks.UninstallCommitMsgHook(hookPath, uninstallForce)
-		if err != nil {
-			return err
-		}
-		if !changed {
-			fmt.Fprintln(cmd.OutOrStdout(), "ℹ️  No commit-msg hook to remove.")
+			changed, backupPath, err := hooks.UninstallCommitMsgHook(hookPath, uninstallForce)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				fmt.Fprintln(cmd.OutOrStdout(), "ℹ️  No commit-msg hook to remove.")
+				return nil
+			}
+
+			if backupPath != "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "✅ Removed hook. Backup saved at", backupPath)
+			} else {
+				fmt.Fprintln(cmd.OutOrStdout(), "✅ Removed Bartle commit-msg hook.")
+			}
 			return nil
-		}
+		},
+	}
+	uninstallHookCmd.Flags().BoolVarP(&uninstallForce, "force", "f", false, "remove hook even if not installed by Bartle (creates a backup)")
 
-		if backupPath != "" {
-			fmt.Fprintln(cmd.OutOrStdout(), "✅ Removed hook. Backup saved at", backupPath)
-		} else {
-			fmt.Fprintln(cmd.OutOrStdout(), "✅ Removed Bartle commit-msg hook.")
-		}
-		return nil
-	},
+	return uninstallHookCmd
 }
 
 func init() {
-	uninstallHookCmd.Flags().BoolVarP(&uninstallForce, "force", "f", false, "remove hook even if not installed by Bartle (creates a backup)")
-	rootCmd.AddCommand(uninstallHookCmd)
+	rootCmd.AddCommand(UninstallHookCommand())
 }


### PR DESCRIPTION
This PR adds functionality to use constructors
for commands, this allows us to test easier and
something we did previously for the version
command. Here we're preparing to write those tests
now for the remaining commands.